### PR TITLE
Add config vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,55 @@ The FQDN or IP address and port Kibana should use.
 
 The URL (including port) over which Kibana will connect to Elasticsearch.
 
+    kibana_server_maxPayloadBytes: 1048576
+
+The maximum payload size in bytes for incoming server requests.
+
+    kibana_kibana_index: ".kibana"
+
+The index Kibana uses in Elasticsearch to store saved searches, visualizations and dashboards. Kibana creates a new index if the index doesn’t already exist.
+
+    kibana_kibana_defaultAppId: "discover"
+
+The default application to load.
+
+    kibana_elasticsearch_pingTimeout: 1500
+
+Time in milliseconds to wait for Elasticsearch to respond to pings.
+
+    kibana_elasticsearch_requestTimeout: 30000
+
+Time in milliseconds to wait for responses from the back end or Elasticsearch. This value must be a positive integer.
+
+    kibana_elasticsearch_shardTimeout: 0
+
+Time in milliseconds for Elasticsearch to wait for responses from shards. Set to 0 to disable.
+
+    kibana_elasticsearch_startupTimeout: 5000
+
+Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying.
+
+    kibana_pid_file: /var/run/kibana.pid
+
+The path where Kibana creates the process ID file.
+
+    kibana_logging_dest: stdout
+
+The file where Kibana stores log output.
+
+    kibana_logging_silent: false
+
+Set the value of this setting to true to suppress all logging output.
+
+    kibana_logging_quiet: false
+
+Set the value of this setting to true to suppress all logging output other than error messages.
+
+    kibana_logging_verbose: false
+
+Set the value of this setting to true to log all events, including system usage information and all requests.
+
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,23 @@ kibana_server_port: 5601
 kibana_server_host: "0.0.0.0"
 
 kibana_elasticsearch_url: "http://localhost:9200"
+
+kibana_server_maxPayloadBytes: 1048576
+
+kibana_elasticsearch_url: "http://localhost:9200"
+
+kibana_kibana_index: ".kibana"
+ 
+kibana_kibana_defaultAppId: "discover"
+
+kibana_elasticsearch_pingTimeout: 1500
+kibana_elasticsearch_requestTimeout: 30000
+kibana_elasticsearch_shardTimeout: 0
+kibana_elasticsearch_startupTimeout: 5000
+
+kibana_pid_file: /var/run/kibana.pid
+
+kibana_logging_dest: stdout
+kibana_logging_silent: false
+kibana_logging_quiet: false
+kibana_logging_verbose: false 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,6 @@ kibana_elasticsearch_url: "http://localhost:9200"
 
 kibana_server_maxPayloadBytes: 1048576
 
-kibana_elasticsearch_url: "http://localhost:9200"
-
 kibana_kibana_index: ".kibana"
  
 kibana_kibana_defaultAppId: "discover"

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -9,7 +9,7 @@ server.host: {{ kibana_server_host }}
 # server.basePath: ""
 
 # The maximum payload size in bytes on incoming server requests.
-# server.maxPayloadBytes: 1048576
+server.maxPayloadBytes: {{ kibana_server_maxPayloadBytes }}
 
 # The Elasticsearch instance to use for all your queries.
 elasticsearch.url: {{ kibana_elasticsearch_url }}
@@ -20,10 +20,10 @@ elasticsearch.url: {{ kibana_elasticsearch_url }}
 
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations
 # and dashboards. It will create a new index if it doesn't already exist.
-# kibana.index: ".kibana"
+kibana.index: {{ kibana_kibana_index }}
 
 # The default application to load.
-# kibana.defaultAppId: "discover"
+kibana.defaultAppId: {{ kibana_kibana_defaultAppId }}
 
 # If your Elasticsearch is protected with basic auth, these are the user credentials
 # used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana
@@ -50,11 +50,11 @@ elasticsearch.url: {{ kibana_elasticsearch_url }}
 
 # Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
 # request_timeout setting
-# elasticsearch.pingTimeout: 1500
+elasticsearch.pingTimeout: {{ kibana_elasticsearch_pingTimeout }}
 
 # Time in milliseconds to wait for responses from the back end or elasticsearch.
 # This must be > 0
-# elasticsearch.requestTimeout: 30000
+elasticsearch.requestTimeout: {{ kibana_elasticsearch_requestTimeout }}
 
 # Header names and values that are sent to Elasticsearch. Any custom headers cannot be overwritten
 # by client-side headers.
@@ -62,22 +62,22 @@ elasticsearch.url: {{ kibana_elasticsearch_url }}
 
 # Time in milliseconds for Elasticsearch to wait for responses from shards.
 # Set to 0 to disable.
-# elasticsearch.shardTimeout: 0
+elasticsearch.shardTimeout: {{ kibana_elasticsearch_shardTimeout }}
 
 # Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
-# elasticsearch.startupTimeout: 5000
+elasticsearch.startupTimeout: {{ kibana_elasticsearch_startupTimeout }}
 
 # Set the path to where you would like the process id file to be created.
-# pid.file: /var/run/kibana.pid
+pid.file: {{ kibana_pid_file }}
 
 # If you would like to send the log output to a file you can set the path below.
-# logging.dest: stdout
+logging.dest: {{ kibana_logging_dest }}
 
 # Set this to true to suppress all logging output.
-# logging.silent: false
+logging.silent: {{ kibana_logging_silent }}
 
 # Set this to true to suppress all logging output except for error messages.
-# logging.quiet: false
+logging.quiet: {{ kibana_logging_quiet }}
 
 # Set this to true to log all events, including system usage information and all requests.
-# logging.verbose: false
+logging.verbose: {{ kibana_logging_verbose }}


### PR DESCRIPTION
Dear Jeff Geerling,

I added support for specifying the following kibana configuration options through ansible vars:
     - kibana_server_maxPayloadBytes
     - kibana_elasticsearch_url
     - kibana_kibana_index
     - kibana_kibana_defaultAppId
     - kibana_elasticsearch_pingTimeout
     - kibana_elasticsearch_requestTimeout
     - kibana_elasticsearch_shardTimeout
     - kibana_elasticsearch_startupTimeout
     - kibana_pid_file
     - kibana_logging_dest
     - kibana_logging_silent
     - kibana_logging_quiet
     - kibana_logging_verbose

https://www.elastic.co/guide/en/kibana/4.6/kibana-server-properties.html

Best regards,
José Lourenço