### PR TITLE
Fix directory missing for kibana/config on Ubuntu

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -12,3 +12,9 @@
     repo: 'deb https://packages.elastic.co/kibana/{{ kibana_version }}/debian stable main'
     state: present
     update_cache: yes
+
+- name: Create kibana config directory
+  sudo: true
+  file:
+    path: /opt/kibana/config
+    state: directory


### PR DESCRIPTION
I'm getting this error:
```
TASK [geerlingguy.kibana : Copy Kibana configuration.] *************************
fatal: [ec2-54-163-156-50.compute-1.amazonaws.com]: FAILED! => {"changed": true, "failed": true, "msg": "Destination directory /opt/kibana/config does not exist"}
```

When i created the directory it works.

Ubuntu: trusty