### PR TITLE
Version selector doesn't work for 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    kibana_version: "4.6"
-
-The version of kibana to install (major and minor only).
-
     kibana_server_port: 5601
     kibana_server_host: "0.0.0.0"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-kibana_version: "4.6"
-
 kibana_server_port: 5601
 kibana_server_host: "0.0.0.0"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Copy Kibana configuration.
   template:
     src: kibana.yml.j2
-    dest: "/opt/kibana/config/kibana.yml"
+    dest: "/etc/kibana/kibana.yml"
     owner: root
     group: root
     mode: 0644

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,11 +4,11 @@
 
 - name: Add Elasticsearch apt key.
   apt_key:
-    url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
 
 - name: Add Kibana repository.
   apt_repository:
-    repo: 'deb https://packages.elastic.co/kibana/{{ kibana_version }}/debian stable main'
+    repo: 'deb https://artifacts.elastic.co/packages/5.x/apt stable main'
     state: present
     update_cache: yes

--- a/templates/kibana.repo.j2
+++ b/templates/kibana.repo.j2
@@ -1,6 +1,6 @@
-[kibana-{{ kibana_version }}]
-name=Kibana repository for {{ kibana_version }}.x packages
-baseurl=https://packages.elastic.co/kibana/{{ kibana_version }}/centos
+[kibana-5.x]
+name=Kibana repository for 5.x packages
+baseurl=https://artifacts.elastic.co/packages/5.x/yum
 gpgcheck=1
-gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1


### PR DESCRIPTION
I've removed the version selector here as it doesn't play well with version 5.x. I believe this is a good feature but it should be implemented better, maybe even install via URL like [elastic/ansible-elasticsearch](https://github.com/elastic/ansible-elasticsearch/) provides.