### PR TITLE
Updated role to default to newest kibana (6.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    kibana_version: "4.6"
+    kibana_version: "6.x"
 
 The version of kibana to install (major and minor only).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-kibana_version: "4.6"
+kibana_version: "6.x"
 
 kibana_server_port: 5601
 kibana_server_host: "0.0.0.0"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Install Kibana.
@@ -17,7 +17,7 @@
 - name: Copy Kibana configuration.
   template:
     src: kibana.yml.j2
-    dest: "/opt/kibana/config/kibana.yml"
+    dest: "/etc/kibana/kibana.yml"
     owner: root
     group: root
     mode: 0644

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,11 +4,11 @@
 
 - name: Add Elasticsearch apt key.
   apt_key:
-    url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
 
 - name: Add Kibana repository.
   apt_repository:
-    repo: 'deb https://packages.elastic.co/kibana/{{ kibana_version }}/debian stable main'
+    repo: 'deb https://artifacts.elastic.co/packages/{{ kibana_version }}/apt stable main'
     state: present
     update_cache: yes

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Elasticsearch GPG key.
   rpm_key:
-    key: https://packages.elastic.co/GPG-KEY-elasticsearch
+    key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
 
 - name: Add Kibana repository.

--- a/templates/kibana.repo.j2
+++ b/templates/kibana.repo.j2
@@ -1,6 +1,8 @@
 [kibana-{{ kibana_version }}]
-name=Kibana repository for {{ kibana_version }}.x packages
-baseurl=https://packages.elastic.co/kibana/{{ kibana_version }}/centos
+name=Kibana repository for {{ kibana_version }} packages
+baseurl=https://artifacts.elastic.co/packages/{{ kibana_version }}/yum
 gpgcheck=1
-gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1
+autorefresh=1
+type=rpm-md


### PR DESCRIPTION
Elastic changed URI for newer releases (5.x and 6.x).
Older Versions than 5.x are not possible any more! #BreakingChange