### PR TITLE
add logic branching for >= 5.x versions of kibana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.retry
 tests/test.sh
+.idea

--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
+(for sub 5.x)
+
     kibana_version: "4.6"
+    
+(for >= 5.x)    
+
+    kibana_version: "5.x"    
+    kibana_version: "6.x"
 
 The version of kibana to install (major and minor only).
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,3 +22,14 @@
     group: root
     mode: 0644
   notify: restart kibana
+  when: kibana_version is version_compare('5', '<')
+
+- name: Copy Kibana configuration.
+  template:
+    src: kibana.yml.j2
+    dest: "/etc/kibana/kibana.yml"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart kibana
+  when: kibana_version is version_compare('5', '>=')

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -2,13 +2,28 @@
 - name: Ensure dependency is installed (Ubuntu).
   apt: name=apt-transport-https state=present
 
-- name: Add Elasticsearch apt key.
+- name: Add Elasticsearch apt key (< 5.x).
   apt_key:
     url: https://packages.elastic.co/GPG-KEY-elasticsearch
     state: present
+  when: kibana_version is version_compare('5', '<')
 
-- name: Add Kibana repository.
+- name: Add Elasticsearch apt key (>= 5.x).
+  apt_key:
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    state: present
+  when: kibana_version is version_compare('5', '>=')
+
+- name: Add Kibana repository (< 5.x)..
   apt_repository:
-    repo: 'deb https://packages.elastic.co/kibana/{{ kibana_version }}/debian stable main'
+    repo: 'deb https://packages.elastic.co/kibana/{{ kibana_version }}/apt stable main'
     state: present
     update_cache: yes
+  when: kibana_version is version_compare('5', '<')
+
+- name: Add Kibana repository (>= 5.x)..
+  apt_repository:
+    repo: 'deb https://artifacts.elastic.co/packages/{{ kibana_version }}/apt stable main'
+    state: present
+    update_cache: yes
+  when: kibana_version is version_compare('5', '>=')

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,8 +1,15 @@
 ---
-- name: Add Elasticsearch GPG key.
+- name: Add Elasticsearch GPG key (< 5.x).
   rpm_key:
     key: https://packages.elastic.co/GPG-KEY-elasticsearch
     state: present
+  when: kibana_version is version_compare('5', '<')
+
+- name: Add Elasticsearch GPG key (>= 5.x).
+  rpm_key:
+    key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    state: present
+  when: kibana_version is version_compare('5', '>=')
 
 - name: Add Kibana repository.
   template:

--- a/templates/kibana.repo.j2
+++ b/templates/kibana.repo.j2
@@ -1,6 +1,14 @@
 [kibana-{{ kibana_version }}]
 name=Kibana repository for {{ kibana_version }}.x packages
+{% if kibana_version | version_compare('5', '<')  %}
 baseurl=https://packages.elastic.co/kibana/{{ kibana_version }}/centos
+{% else %}
+baseurl=https://artifacts.elastic.co/packages/{{ kibana_version }}/centos
+{% endif %}
 gpgcheck=1
+{% if kibana_version | version_compare('5', '<')  %}
 gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
+{% else %}
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+{% endif %}
 enabled=1


### PR DESCRIPTION
hey @geerlingguy , so here's my approach to solving the handling of newer versions. A bit of extra logic branching and it in theory may serve the purpose for >= 5.x Kibana. **However** all my today's attempts to install that on a vanilla 16.04 and 18.04 went to dumpster with errors around:
(this one's from 18.04; the 16.04's was a bit different but similar in nature)
```
W:The repository '[...]' does not have a Release file., 
W:Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
```
I couldn't solve that even manually with some basic/moderate linux commands. Including stuff like disabling ipv6, juggling certificates manually, reinstalling everything until it hurt.
Maybe something with my ISP though, so em posting anyways in hope people can solve that for themselves.
In the end have ended up installing `.deb` directly... and that worked (almost) flawlessly.