### PR TITLE
Allow the logging destination to be specified. 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,5 @@ kibana_server_host: "0.0.0.0"
 kibana_elasticsearch_url: "http://localhost:9200"
 kibana_elasticsearch_username: ""
 kibana_elasticsearch_password: ""
+
+kibana_logging_dest: "stdout"

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -98,7 +98,9 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 #pid.file: /var/run/kibana.pid
 
 # Enables you specify a file where Kibana stores log output.
-#logging.dest: stdout
+{% if kibana_logging_dest %}
+logging.dest: "{{ kibana_logging_dest }}"
+{% endif %}
 
 # Set the value of this setting to true to suppress all logging output.
 #logging.silent: false


### PR DESCRIPTION
I was running into an issue with Kibana which was difficult to resolve without a log, as the instance was restarting. The log destination is an option in the Kibana configuration that can be given the name of a file to dump the log to. 

The default variables do not include a way to set this. They do cover other Kibana options, so I've added another variable to set this. It will still default to stdout, albeit explicitly. 