### PR TITLE
7.x fix

### DIFF
--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -26,9 +26,9 @@ server.host: "{{ kibana_server_host }}"
 
 # The URL of the Elasticsearch instance to use for all your queries.
 {% if kibana_version == "7.x" %}
-elasticsearch.url: {{ kibana_elasticsearch_url }}
-{% else %}
 elasticsearch.hosts: [ {{ kibana_elasticsearch_url }} ]
+{% else %}
+elasticsearch.url: {{ kibana_elasticsearch_url }}
 {% endif %}
 
 # When this setting's value is true Kibana uses the hostname specified in the server.host

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -25,7 +25,11 @@ server.host: "{{ kibana_server_host }}"
 #server.name: "your-hostname"
 
 # The URL of the Elasticsearch instance to use for all your queries.
+{% if kibana_version == "7.x" %}
 elasticsearch.url: {{ kibana_elasticsearch_url }}
+{% else %}
+elasticsearch.hosts: [ {{ kibana_elasticsearch_url }} ]
+{% endif %}
 
 # When this setting's value is true Kibana uses the hostname specified in the server.host
 # setting. When the value of this setting is false, Kibana uses the hostname of the host


### PR DESCRIPTION
A quick fix to allow a 7.x install to run pre-configuration.
---
```elasticsearch.url is no longer validedit
Details: The deprecated elasticsearch.url setting in the kibana.yml file has been removed.

Impact: Use elasticsearch.hosts instead. In prior versions of Kibana, if no port was specified in elasticsearch.url, a default of 9200 was chosen. The port in elasticsearch.hosts is protocol dependent: https ports will use 443, and http ports will use 80. If your elasticsearch.url setting was dependent on an unspecified port set to 9200, append :9200 to the url in the elasticsearch.hosts setting.```