### PR TITLE
Add ssl support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,15 @@ kibana_server_host: "0.0.0.0"
 kibana_elasticsearch_url: "http://localhost:9200"
 kibana_elasticsearch_username: ""
 kibana_elasticsearch_password: ""
+
+kibana_enable_ssl: false
+kibana_insecure_ssl: false   # enable when using a self-signed cert and not a custom CA
+kibana_ssl_dir: /etc/pki/kibana
+kibana_ssl_key_file: ""
+kibana_ssl_certificate_file: ""
+kibana_ssl_certificate_authority:    # useful when using your own Certificate Authority
+
+kibana_es_uses_ssl: false
+kibana_es_ssl_dir: /etc/pki/kibana
+kibana_es_ssl_certificate_file: ""
+kibana_es_ssl_key_file: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,8 @@
     state: "{{ kibana_service_state }}"
     enabled: "{{ kibana_service_enabled }}"
 
+- include: ssl.yml
+
 - name: Copy Kibana configuration.
   template:
     src: "{{ kibana_config_template }}"

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -1,0 +1,42 @@
+---
+- local_action: stat path="{{ role_path }}/files/{{ kibana_ssl_key_file }}"
+  register: kibana_keyfile
+
+- local_action: stat path="{{ role_path }}/files/{{ kibana_ssl_certificate_file }}"
+  register: kibana_crtfile
+
+- local_action: stat path="{{ role_path }}/files/{{ kibana_ssl_certificate_authority }}"
+  register: kibana_cafile
+
+- name: ensure certificate directory exists
+  file:
+    dest: "{{ kibana_ssl_dir }}"
+    state: directory
+    mode: 0700
+    owner: kibana
+    group: kibana 
+
+- name: Copy Kibana SSL/TLS certificate
+  copy:
+    src: "{{ kibana_ssl_certificate_file }}"
+    dest: "{{ kibana_ssl_dir }}/{{ kibana_ssl_certificate_file | basename }}"
+    mode: 0600
+    owner: kibana
+    group: kibana
+  when: kibana_crtfile.stat.exists|bool and kibana_crtfile.stat.isreg|bool
+
+- name: Copy Kibana SSL/TLS key
+  copy:
+    src: "{{ kibana_ssl_key_file }}"
+    dest: "{{ kibana_ssl_dir }}/{{ kibana_ssl_key_file | basename }}"
+    mode: 0600
+    owner: kibana
+    group: kibana
+  when: kibana_keyfile.stat.exists|bool and kibana_keyfile.stat.isreg|bool
+
+- name: Configure certificate authority
+  copy:
+    src: "{{ kibana_ssl_certificate_authority }}"
+    dest: "{{ kibana_ssl_dir }}/{{ kibana_ssl_certificate_authority | basename }}"
+    mode: 0644
+  when: kibana_cafile.stat.exists|bool and kibana_cafile.stat.isreg|bool

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -25,7 +25,7 @@ server.host: "{{ kibana_server_host }}"
 #server.name: "your-hostname"
 
 # The URL of the Elasticsearch instance to use for all your queries.
-elasticsearch.hosts: {{ kibana_elasticsearch_url }}
+elasticsearch.hosts: "{{ kibana_elasticsearch_url }}"
 
 # When this setting's value is true Kibana uses the hostname specified in the server.host
 # setting. When the value of this setting is false, Kibana uses the hostname of the host
@@ -53,9 +53,16 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 
 # Enables SSL and paths to the PEM-format SSL certificate and SSL key files, respectively.
 # These settings enable SSL for outgoing requests from the Kibana server to the browser.
-#server.ssl.enabled: false
+
+{% if kibana_enable_ssl | bool %}
+server.ssl.enabled: true
+server.ssl.certificate: "{{ kibana_ssl_dir }}/{{ kibana_ssl_certificate_file | basename }}"
+server.ssl.key: "{{ kibana_ssl_dir }}/{{ kibana_ssl_key_file | basename }}"
+{% else %}
+server.ssl.enabled: false
 #server.ssl.certificate: /path/to/your/server.crt
 #server.ssl.key: /path/to/your/server.key
+{% endif %}
 
 # Optional settings that provide the paths to the PEM-format SSL certificate and key files.
 # These files validate that your Elasticsearch backend uses the same key files.
@@ -64,10 +71,18 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 
 # Optional setting that enables you to specify a path to the PEM file for the certificate
 # authority for your Elasticsearch instance.
+{% if kibana_cafile.stat.exists|bool and kibana_cafile.stat.isreg|bool %}
+elasticsearch.ssl.certificateAuthorities: [ "{{ kibana_ssl_dir }}/{{ kibana_ssl_certificate_authority | basename }}" ]
+{% else %}
 #elasticsearch.ssl.certificateAuthorities: [ "/path/to/your/CA.pem" ]
+{% endif %}
 
 # To disregard the validity of SSL certificates, change this setting's value to 'none'.
+{% if kibana_insecure_ssl | bool %}
+elasticsearch.ssl.verificationMode: none
+{% else %}
 #elasticsearch.ssl.verificationMode: full
+{% endif %}
 
 # Time in milliseconds to wait for Elasticsearch to respond to pings. Defaults to the value of
 # the elasticsearch.requestTimeout setting.

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -25,7 +25,7 @@ server.host: "{{ kibana_server_host }}"
 #server.name: "your-hostname"
 
 # The URL of the Elasticsearch instance to use for all your queries.
-elasticsearch.url: {{ kibana_elasticsearch_url }}
+elasticsearch.hosts: {{ kibana_elasticsearch_url }}
 
 # When this setting's value is true Kibana uses the hostname specified in the server.host
 # setting. When the value of this setting is false, Kibana uses the hostname of the host


### PR DESCRIPTION
Add SSL support to kibana configs

Add several new variables to enable SSL/TLS support in Kibana, both for
the front-end and for connections to ElasticSearch.

Support for SSL/TLS was added in the "Basic" version of ElasticSearch &
Kibana starting with the 7.1.0 release.
 
It assumes certificates are generated externally, and only handles
uploading and configuring the server accordingly.
