### PR TITLE
Fix linting

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,6 @@
 ---
 extends: default
+ignore: .github/stale.yml
 rules:
   line-length:
     max: 120

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint
+  ansible-lint .
 platforms:
   - name: instance
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"


### PR DESCRIPTION
Hi. Thanks a lot for your work. I love it.

I was trying the command `molecule lint` and I found two issues:
* It was failing because `ansible-lint` was expecting a file or directory.
* `yamllint` was giving some errors because a file not related with the role itself: `.github/stale.yml`

I add two changes to fix both issues. Now the command `molecule lint` run with smoothly. I hope the changes are good enough to be added.

Versions used:
* **Ansible**: 2.9.6
* **Molecule**: 3.0.2
* **Yamllint**: 1.19.0
* **Python**: 3.8.0