### PR TITLE
Feature: Add kibana_extra_options variable to support arbitrary options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ The URL (including port) over which Kibana will connect to Elasticsearch.
 
 If Elasticsearch is protected by HTTP basic authentication, set the username and password so Kibana can connect.
 
+    kibana_extra_options: ''
+
+A placeholder for arbitrary configuration options not exposed by the role. This will be appended as-is to the end of the `kibana.yml` file, as long as your variable preserves formatting with a `|`. For example:
+
+```yaml
+kibana_extra_options: | # Don't forget the pipe!
+  some.option: true
+  another.option: false
+```
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,5 @@ kibana_server_host: "0.0.0.0"
 kibana_elasticsearch_url: "http://localhost:9200"
 kibana_elasticsearch_username: ""
 kibana_elasticsearch_password: ""
+
+kibana_extra_options: ''

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -121,3 +121,5 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 # The default locale. This locale can be used in certain circumstances to substitute any missing
 # translations.
 #i18n.defaultLocale: "en"
+
+{{ kibana_extra_options }}


### PR DESCRIPTION
This commit is meant to directly parallel the implementation in https://github.com/geerlingguy/ansible-role-elasticsearch/commit/fb6f14f85183dd1289fad0b5cc3809988dd8846d to allow for implementation of configuration not specified by the role itself.