### PR TITLE
add toggle repo support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 kibana_version: "7.x"
+kibana_add_repo: true
 
 kibana_package: kibana
 kibana_package_state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,13 @@
 ---
 - include: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: 
+    - ansible_os_family == 'RedHat'
+    - kibana_add_repo|bool
 
 - include: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: 
+    - ansible_os_family == 'Debian'
+    - kibana_add_repo|bool
 
 - name: Install Kibana.
   package:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,14 +5,17 @@
       - apt-transport-https
       - gnupg2
     state: present
+  when: kibana_add_repo|bool
 
 - name: Add Elasticsearch apt key.
   apt_key:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
+  when: kibana_add_repo|bool
 
 - name: Add Kibana repository.
   apt_repository:
     repo: 'deb https://artifacts.elastic.co/packages/{{ kibana_version }}/apt stable main'
     state: present
     update_cache: true
+  when: kibana_add_repo|bool


### PR DESCRIPTION
This makes it possible to use this role in setups behind corporate firewalls and compatible with Katello/Redhat satellite management managed hosts.