### PR TITLE
Reduce Log Verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The URL (including port) over which Kibana will connect to Elasticsearch.
 
 If Elasticsearch is protected by HTTP basic authentication, set the username and password so Kibana can connect.
 
+    kibana_logging_quiet: yes
+
+Only commit errors to syslog, stop logging Kibana Access logs
+
 ## Dependencies
 
 None.

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -109,7 +109,7 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 
 # Set the value of this setting to true to suppress all logging output other than error messages.
 {% if kibana_logging_quiet == yes %}
-#logging.quiet: true
+logging.quiet: true
 {% else %}
 #logging.quiet: false
 {% endif %}

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -108,7 +108,11 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 #logging.silent: false
 
 # Set the value of this setting to true to suppress all logging output other than error messages.
+{% if kibana_logging_quiet == yes %}
+#logging.quiet: true
+{% else %}
 #logging.quiet: false
+{% endif %}
 
 # Set the value of this setting to true to log all events, including system usage information
 # and all requests.


### PR DESCRIPTION
I'm a beginner to elk stack, but I've noticed everything I do in Kibana creates a lot of logs by kibana itself. I would prefer if I could change the Verbosity level.

I tried to update the code so I could do that. The added code should do the trick and allow to set the flag to only log errors.