### PR TITLE
add capability to turn off ssl validation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,5 @@ kibana_server_host: "0.0.0.0"
 kibana_elasticsearch_url: "http://localhost:9200"
 kibana_elasticsearch_username: ""
 kibana_elasticsearch_password: ""
+
+kibana_elasticsearch_ssl_verificationMode: full

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -71,7 +71,7 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 #elasticsearch.ssl.certificateAuthorities: [ "/path/to/your/CA.pem" ]
 
 # To disregard the validity of SSL certificates, change this setting's value to 'none'.
-#elasticsearch.ssl.verificationMode: full
+elasticsearch.ssl.verificationMode: {{ kibana_elasticsearch_ssl_verificationMode }}
 
 # Time in milliseconds to wait for Elasticsearch to respond to pings. Defaults to the value of
 # the elasticsearch.requestTimeout setting.


### PR DESCRIPTION
Hi, this is my first contribution to this project, so let me know if I do something wrong.

About the change, when there is a need to use internal load balancer without valid ssl, it is necessary turn off ssl validation in Kibana side.

Variable: kibana_elasticsearch_ssl_verificationMode
Default value: full

Reference: https://www.elastic.co/guide/en/kibana/current/settings.html