### PR TITLE
Added options for repository and additional configuration items

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,4 @@ kibana_elasticsearch_username: ""
 kibana_elasticsearch_password: ""
 
 kibana_config: {}
+kibana_add_repository: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,5 @@ kibana_server_host: "0.0.0.0"
 kibana_elasticsearch_url: "http://localhost:9200"
 kibana_elasticsearch_username: ""
 kibana_elasticsearch_password: ""
+
+kibana_config: {}

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -10,9 +10,11 @@
   apt_key:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
+  when: kibana_add_repository
 
 - name: Add Kibana repository.
   apt_repository:
     repo: 'deb https://artifacts.elastic.co/packages/{{ kibana_version }}/apt stable main'
     state: present
     update_cache: true
+  when: kibana_add_repository

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -3,9 +3,11 @@
   rpm_key:
     key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
+  when: kibana_add_repository
 
 - name: Add Kibana repository.
   template:
     src: kibana.repo.j2
     dest: /etc/yum.repos.d/kibana.repo
     mode: 0644
+  when: kibana_add_repository

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -121,3 +121,7 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 # The default locale. This locale can be used in certain circumstances to substitute any missing
 # translations.
 #i18n.defaultLocale: "en"
+
+{% if kibana_config %}
+{{ kibana_config | to_nice_yaml }}
+{% endif %}

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -25,10 +25,10 @@ server.host: "{{ kibana_server_host }}"
 #server.name: "your-hostname"
 
 # The URL of the Elasticsearch instance to use for all your queries.
-{% if kibana_version == "6.x" %}
-elasticsearch.url: {{ kibana_elasticsearch_url }}
+{% if kibana_version == "7.x" %}
+elasticsearch.hosts: [ {{ kibana_elasticsearch_url }} ]
 {% else %}
-elasticsearch.hosts: {{ kibana_elasticsearch_url }}
+elasticsearch.url: {{ kibana_elasticsearch_url }}
 {% endif %}
 
 # When this setting's value is true Kibana uses the hostname specified in the server.host


### PR DESCRIPTION
The PR contains changes to:

- decide if the elastic repo should be added or not
- add custom configuration items to the Kibana config

Also the logic for the `elasticsearch.hosts` and `elasticsearch.url` was inverted as `.hosts` was added in `7.x` and for versions `6.x` and `5.x` the `.url` is still valid.