### PR TITLE
Add support for server.publicBaseUrl config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The URL (including port) over which Kibana will connect to Elasticsearch.
 
 If Elasticsearch is protected by HTTP basic authentication, set the username and password so Kibana can connect.
 
+    kibana_public_base_url: ""
+
+The publicly available URL that end-users access Kibana at.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,6 @@ kibana_server_host: "0.0.0.0"
 kibana_elasticsearch_url: "http://localhost:9200"
 kibana_elasticsearch_username: ""
 kibana_elasticsearch_password: ""
+
+kibana_public_base_url: ""
+

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -61,6 +61,16 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 #server.ssl.certificate: /path/to/your/server.crt
 #server.ssl.key: /path/to/your/server.key
 
+# The publicly available URL that end-users access Kibana at. Must include the
+# protocol, hostname, port (if different than the defaults for http and https,
+# 80 and 443 respectively), and the server.basePath (if configured). This
+# setting cannot end in a slash (/).
+{% if kibana_public_base_url %}
+server.publicBaseUrl: "{{ kibana_public_base_url }}"
+{% else %}
+#server.publicBaseUrl: "URL"
+{% endif %}
+
 # Optional settings that provide the paths to the PEM-format SSL certificate and key files.
 # These files validate that your Elasticsearch backend uses the same key files.
 #elasticsearch.ssl.certificate: /path/to/your/client.crt


### PR DESCRIPTION
Setting this param is now advised on production deployments. If not set, Kibana will produce warning.